### PR TITLE
Use ruff as main linter

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,8 +19,8 @@ jobs:
         python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -33,3 +33,19 @@ jobs:
 
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run: "python -m tox"
+
+  lint:
+    name: "Lint code with ruff"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff src tests --format "github"

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 # IDE settings
 .vscode/
 .idea/
+
+# ruff cache
+.ruff_cache

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
+<p align="center">
+  <img src="https://github.com/fabiangeisler/pyshotgrid/blob/main/icons/pysg_logo.png?raw=true" />
+</p>
+
 [![pypi](https://img.shields.io/pypi/v/pyshotgrid.svg)](https://pypi.python.org/pypi/pyshotgrid)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/pyshotgrid.svg)](https://pypi.python.org/pypi/pyshotgrid/)
 [![Tests](https://github.com/fabiangeisler/pyshotgrid/actions/workflows/Tests.yml/badge.svg)](https://github.com/fabiangeisler/pyshotgrid/actions/workflows/Tests.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![linter: ruff](https://img.shields.io/static/v1?label=linter&message=ruff&color=green)](https://github.com/charliermarsh/ruff)
+[![type checker: mypy](https://img.shields.io/badge/%20type_checker-my[py]-%231674b1?style=flat)](https://github.com/python/mypy)
 
 `pyshotgrid` is a python package that gives you a pythonic and
 object oriented way to talk to [Autodesk ShotGrid](https://www.autodesk.com/products/shotgrid/overview).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
+html_logo = "../icons/pysg_logo.png"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -13,6 +13,7 @@ any entity to a `pyshotgrid` object instance. What you need for this is:
 - a shotgun_api3.Shotgun instance (which conveniently is present almost everywhere in SGTK)
 - the type of the entity
 - the id of the entity
+
 These parameters will be passed to the `pyshotgrid.new_entity` method, which returns the
 object you want to work with.
 The method accepts 3 ways of passing arguments to it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, py310-flake8
-
-[testenv:py310-flake8]
-exclude = docs
-deps = flake8
-commands = flake8 src tests --max-line-length=100
+    3.10: py310
 
 [testenv:docs]
 description=Documentation generation
@@ -75,7 +70,10 @@ deps =
 commands = nose2 -v --with-coverage --coverage ./src --coverage-report html --coverage-report term
 """
 
-[tool.mypy]
+[[tool.mypy.overrides]]
+module = [
+    "shotgun_api3.*",
+]
 ignore_missing_imports = true
 
 [tool.commitizen]
@@ -88,3 +86,18 @@ major_version_zero = true
 version_files = [
     "src/pyshotgrid/__init__.py:VERSION",
 ]
+
+[tool.ruff]
+line-length = 100
+select = [
+    "E",  # pycodestyle
+    "W",
+    "F",  # PyFlakes
+    "B",  # flake8-bugbear
+    "T20",  # "print" in code
+    "N",  # pep8 naming convention
+    "I",  # isort
+    "RUF",  # Bad unicode characters in code
+]
+
+src = ["src", "tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,9 @@ commitizen;python_version > "2.7"
 wheel
 build
 twine
-flake8
+ruff;python_version > "2.7"
 invoke;python_version > "2.7"
 black;python_version > "2.7"
-isort;python_version > "2.7"
 pre-commit;python_version > "2.7"
 coverage
 nose2

--- a/src/pyshotgrid/__init__.py
+++ b/src/pyshotgrid/__init__.py
@@ -8,15 +8,15 @@ Use it like::
 """
 
 from . import sg_default_entities as sde
-from .core import new_entity  # noqa: F401
-from .core import new_site  # noqa: F401
 from .core import (
+    new_entity,  # noqa: F401
+    new_site,  # noqa: F401
     register_fallback_pysg_class,
     register_pysg_class,
     register_sg_site_class,
 )
 from .sg_entity import Field, SGEntity  # noqa: F401
-from .sg_site import SGSite  # noqa: F401
+from .sg_site import SGSite
 
 #: The pyshotgrid version number as string
 VERSION = "0.8.0"

--- a/src/pyshotgrid/core.py
+++ b/src/pyshotgrid/core.py
@@ -1,14 +1,19 @@
+import typing
 from typing import Any, Dict, List, Type  # noqa: F401
 
 import shotgun_api3
 import shotgun_api3.lib.mockgun
 
+if typing.TYPE_CHECKING:
+    from pyshotgrid.sg_entity import SGEntity  # noqa: F401
+    from pyshotgrid.sg_site import SGSite  # noqa: F401
+
 #: Entity plugins that are registered to pyshotgrid.
 __ENTITY_PLUGINS = []  # type: List[Dict[str,Any]]
 #: Fallback entity class that is used when no match in the __ENTITY_PLUGINS is found.
-__ENTITY_FALLBACK_CLASS = None  # type: Type|None
+__ENTITY_FALLBACK_CLASS = None  # type: Type[SGEntity]|None
 #: The class that represents the ShotGrid site.
-__SG_SITE_CLASS = None  # type: Type|None
+__SG_SITE_CLASS = None  # type: Type[SGSite]|None
 
 
 def new_entity(sg, *args, **kwargs):
@@ -216,7 +221,8 @@ def convert_filters_to_dict(filters):
 
     Example::
 
-        >>> convert_filters_to_dict([['user', 'is', SGHumanUser(sg, id=5)]])
+        >>> person = SGEntity(shotgun_api3.Shotgun('...'), entity_type='HumanUser', entity_id=5)
+        >>> convert_filters_to_dict([['user', 'is', person]])
         [['user', 'is', {'type': 'HumanUser', 'id': 5}]]
 
     :param list[list] filters: The filters to convert

--- a/tests/test_sg_entity.py
+++ b/tests/test_sg_entity.py
@@ -11,9 +11,9 @@ else:
 
 from shotgun_api3.lib import mockgun
 
-from .testbase import BaseShotGridTest
-
 import pyshotgrid as pysg
+
+from .testbase import BaseShotGridTest
 
 
 class TestSGEntity(BaseShotGridTest):


### PR DESCRIPTION
This PR will introduce ruff as main linter
for the repository.

Changes:

- build(lint): add ruff as linter
- ci(GitActions): add ruff git action for code linting
- style(pysg): apply ruff and mypy changes
- docs(README): add logo and badges for ruff and mypy

