### PR TITLE
fix(SGEntity): do not cast url fields to Attachment SGEntities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,8 +77,8 @@ def sg():
 
     mockgun.Shotgun.update = patched_update
 
-    # Patching the mockgun.Shotgun.find method because it is missing 2 arguments "include_archived_projects" and
-    # "additional_filter_presets".
+    # Patching the mockgun.Shotgun.find method because it is missing 2 arguments
+    # "include_archived_projects" and "additional_filter_presets".
     def patched_find(
         self,
         entity_type,
@@ -110,7 +110,8 @@ def sg():
 
         if isinstance(filters, dict):
             # complex filter style!
-            # {'conditions': [{'path': 'id', 'relation': 'is', 'values': [1]}], 'logical_operator': 'and'}
+            # {'conditions': [{'path': 'id', 'relation': 'is', 'values': [1]}],
+            #                 'logical_operator': 'and'}
 
             resolved_filters = []
             for f in filters["conditions"]:
@@ -145,7 +146,8 @@ def sg():
             for order_entry in order:
                 if "field_name" not in order_entry:
                     raise ValueError(
-                        "Order clauses must be list of dicts with keys 'field_name' and 'direction'!"
+                        "Order clauses must be list of dicts with keys "
+                        "'field_name' and 'direction'!"
                     )
 
                 order_field = order_entry["field_name"]
@@ -349,25 +351,20 @@ def add_default_entities(sg):
                     "link_type": "local",
                     "name": "sh1111_city_v{:03d}.%04d.exr".format(i),
                     "local_storage": local_storage,
-                    "local_path_mac": "/Volumes/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.exr".format(
-                        i
-                    ),
-                    "local_path_linux": "/mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.exr".format(
-                        i
-                    ),
-                    "local_path_windows": "P:\\tp\\sequences\\sq111\\sh1111_city_v{:03d}.%04d.exr".format(
-                        i
-                    ),
+                    "local_path_mac": "/Volumes/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.exr".format(i),
+                    "local_path_linux": "/mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.exr".format(i),
+                    "local_path_windows": "P:\\tp\\sequences\\sq111\\"
+                    "sh1111_city_v{:03d}.%04d.exr".format(i),
                     "type": "Attachment",
                     "id": random.randint(1, 1000),
-                    "local_path": "/mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.exr".format(
-                        i
-                    ),
-                    "url": "file:///mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.exr".format(
-                        i
-                    ),
+                    "local_path": "/mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.exr".format(i),
+                    "url": "file:///mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.exr".format(i),
                 },
-                "path_cache": "tp/sequences/sq111/sh1111_city_v{:03d}.%04d.exr".format(i),
+                "path_cache": "tp/sequences/sq111/" "sh1111_city_v{:03d}.%04d.exr".format(i),
                 "path_cache_storage": local_storage,
                 "created_by": person_a,
             },
@@ -388,23 +385,18 @@ def add_default_entities(sg):
                     "link_type": "local",
                     "name": "sh1111_city_v{:03d}.%04d.abc".format(i),
                     "local_storage": local_storage,
-                    "local_path_mac": "/Volumes/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.abc".format(
-                        i
-                    ),
-                    "local_path_linux": "/mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.abc".format(
-                        i
-                    ),
-                    "local_path_windows": "P:\\tp\\sequences\\sq111\\sh1111_city_v{:03d}.%04d.abc".format(
-                        i
-                    ),
+                    "local_path_mac": "/Volumes/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.abc".format(i),
+                    "local_path_linux": "/mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.abc".format(i),
+                    "local_path_windows": "P:\\tp\\sequences\\sq111\\"
+                    "sh1111_city_v{:03d}.%04d.abc".format(i),
                     "type": "Attachment",
                     "id": random.randint(1, 1000),
-                    "local_path": "/mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.abc".format(
-                        i
-                    ),
-                    "url": "file:///mnt/projects/tp/sequences/sq111/sh1111_city_v{:03d}.%04d.abc".format(
-                        i
-                    ),
+                    "local_path": "/mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.abc".format(i),
+                    "url": "file:///mnt/projects/tp/sequences/sq111/"
+                    "sh1111_city_v{:03d}.%04d.abc".format(i),
                 },
                 "path_cache": "tp/sequences/sq111/sh1111_city_v{:03d}.abc".format(i),
                 "path_cache_storage": local_storage,

--- a/tests/test_core/test_field.py
+++ b/tests/test_core/test_field.py
@@ -38,6 +38,51 @@ def test_get(sg):
     assert "Test Project A" == result
 
 
+def test_get__url_field_no_value(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v001.abc"]])
+    sg_path_field = pysg.core.Field("path", sg_publish)
+
+    result = sg_path_field.get()
+
+    assert result is None
+
+
+def test_get__url_field_web_url(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v002.abc"]])
+    sg_path_field = pysg.core.Field("path", sg_publish)
+
+    result = sg_path_field.get()
+
+    assert result == "https://www.google.com/"
+
+
+def test_get__url_field_upload_value(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v003.abc"]])
+    sg_path_field = pysg.core.Field("path", sg_publish)
+
+    result = sg_path_field.get()
+
+    assert result == {
+        "content_type": None,
+        "id": 123456,
+        "link_type": "upload",
+        "name": "test.txt",
+        "type": "Attachment",
+        "url": "https://sg-media-ireland.s3-accelerate.amazonaws.com/ffeb...",
+    }
+
+
+def test_get__url_field_local_path_value(sg):
+    sg_publish = pysg.new_site(sg).find_one(
+        "PublishedFile", [["code", "is", "sh1111_city_v001.%04d.exr"]]
+    )
+    sg_path_field = pysg.core.Field("path", sg_publish)
+
+    result = sg_path_field.get()
+
+    assert result == "/mnt/projects/tp/sequences/sq111/sh1111_city_v001.%04d.exr"
+
+
 def test_get_raw_values(sg):
     sg_project = pysg.new_entity(sg, 1, "Project")
     sg_users_field = pysg.core.Field("users", sg_project)

--- a/tests/test_core/test_sg_entity.py
+++ b/tests/test_core/test_sg_entity.py
@@ -35,18 +35,68 @@ def test_get(sg):
     assert {"name": "Test Project A", "tank_name": "tpa"} == sg_entity.get(["name", "tank_name"])
 
 
+def test_get__url_field_no_value(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v001.abc"]])
+
+    result = sg_publish.get(["code", "path"])
+
+    assert result == {"code": "CarA_mdl_v001.abc", "path": None}
+
+
+def test_get__url_field_web_url(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v002.abc"]])
+
+    result = sg_publish.get(["code", "path"])
+
+    assert result == {"code": "CarA_mdl_v002.abc", "path": "https://www.google.com/"}
+
+
+def test_get__url_field_upload_value(sg):
+    sg_publish = pysg.new_site(sg).find_one("PublishedFile", [["code", "is", "CarA_mdl_v003.abc"]])
+
+    result = sg_publish.get(["code", "path"])
+
+    assert result == {
+        "code": "CarA_mdl_v003.abc",
+        "path": {
+            "content_type": None,
+            "id": 123456,
+            "link_type": "upload",
+            "name": "test.txt",
+            "type": "Attachment",
+            "url": "https://sg-media-ireland.s3-accelerate.amazonaws.com/ffeb...",
+        },
+    }
+
+
+def test_get__url_field_local_path_value(sg):
+    sg_publish = pysg.new_site(sg).find_one(
+        "PublishedFile", [["code", "is", "sh1111_city_v001.%04d.exr"]]
+    )
+
+    result = sg_publish.get(["code", "path"])
+
+    assert result == {
+        "code": "sh1111_city_v001.%04d.exr",
+        "path": "/mnt/projects/tp/sequences/sq111/sh1111_city_v001.%04d.exr",
+    }
+
+
 def test_name(sg):
     sg_project = pysg.new_entity(sg, 1, "Project")
     sg_task = pysg.new_entity(sg, 1, "Task")
     sg_asset = pysg.new_entity(sg, 1, "Asset")
+    sg_tag = pysg.new_entity(sg, 1, "Tag")
 
     result_project_name_field = sg_project.name
     result_task_name_field = sg_task.name
     result_asset_name_field = sg_asset.name
+    result_tag_name_field = sg_tag.name
 
     assert "name" == result_project_name_field.name
     assert "content" == result_task_name_field.name
     assert "code" == result_asset_name_field.name
+    assert "name" == result_tag_name_field.name
 
 
 def test_thumbnail(sg):

--- a/tests/test_core/test_sg_site.py
+++ b/tests/test_core/test_sg_site.py
@@ -10,18 +10,7 @@ import pyshotgrid as pysg
 def test_project(sg):
     sg_site = pysg.SGSite(sg)
 
-    # Mock Mockgun.Shotgun.find - the "include_archived_projects" arg is missing in Mockgun.
-    with mock.patch.object(
-        mockgun.Shotgun,
-        "find",
-        return_value=[
-            {
-                "type": "Project",
-                "id": 1,
-            }
-        ],
-    ):
-        result = sg_site.project(1)
+    result = sg_site.project(1)
 
     assert result.type == "Project"
     assert result.id == 1
@@ -81,22 +70,7 @@ def test_create(sg):
 def test_find(sg):
     sg_site = pysg.SGSite(sg)
 
-    # Mock Mockgun.Shotgun.find - the "include_archived_projects" arg is missing in Mockgun.
-    with mock.patch.object(
-        mockgun.Shotgun,
-        "find",
-        return_value=[
-            {
-                "type": "Asset",
-                "id": 2,
-            },
-            {
-                "type": "Asset",
-                "id": 3,
-            },
-        ],
-    ):
-        result = sg_site.find("Asset", [["code", "contains", "Car"]])
+    result = sg_site.find("Asset", [["code", "contains", "Car"]])
 
     for asset in result:
         assert asset.type == "Asset"
@@ -106,18 +80,7 @@ def test_find(sg):
 def test_find_one(sg):
     sg_site = pysg.SGSite(sg)
 
-    # Mock Mockgun.Shotgun.find - the "include_archived_projects" arg is missing in Mockgun.
-    with mock.patch.object(
-        mockgun.Shotgun,
-        "find",
-        return_value=[
-            {
-                "type": "Asset",
-                "id": 1,
-            }
-        ],
-    ):
-        result = sg_site.find_one("Asset", [["code", "contains", "Tree"]])
+    result = sg_site.find_one("Asset", [["code", "contains", "Tree"]])
 
     assert result.type == "Asset"
     assert "Tree" in result["code"].get()
@@ -126,9 +89,7 @@ def test_find_one(sg):
 def test_find_one__returns_none_when_nothing_found(sg):
     sg_site = pysg.SGSite(sg)
 
-    # Mock Mockgun.Shotgun.find - the "include_archived_projects" arg is missing in Mockgun.
-    with mock.patch.object(mockgun.Shotgun, "find", return_value=[]):
-        result = sg_site.find_one("Asset", [["code", "contains", "Not existent name"]])
+    result = sg_site.find_one("Asset", [["code", "contains", "Not existent name"]])
 
     assert result is None
 

--- a/tests/test_sg_default_entities/test_sg_asset.py
+++ b/tests/test_sg_default_entities/test_sg_asset.py
@@ -13,7 +13,7 @@ def test_tasks(sg):
 
 
 def test_publishes(sg):
-    sg_asset = sde.SGAsset(sg, 1)
+    sg_asset = sde.SGAsset(sg, 2)
 
     result = sg_asset.publishes()
 


### PR DESCRIPTION
Fields with type "url" will now return their values as follows:
 * Uploaded Files:
    Will return the dict that describes the uploaded file attachment,
    so you can pass it on to Shotgun.download_attachment().
 * Link to local files:
    Will return the platform dependent absolute path to the linked file.
 * Link to a URL:
    Will return the URL.