### PR TITLE
feat(PyPI): Use shotgun-api3 from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ object oriented way to talk to [Autodesk ShotGrid](https://www.autodesk.com/prod
 Install `pyshotgrid` via pip:
 
 ```shell
-pip install git+https://github.com/shotgunsoftware/python-api.git@v3.4.0
 pip install pyshotgrid
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
   { name="Fabian Geisler", email="info@fasbue.com" },
 ]
 description = "A pythonic and object oriented way to talk to Autodesk ShotGrid."
+dependencies = ["shotgun-api3>=3.4.0"]
 readme.file = "README.md"
 readme.content-type = "text/markdown"
 license.text="MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/shotgunsoftware/python-api.git@v3.4.0
+shotgun-api3==v3.4.0
 commitizen
 wheel
 build

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
-git+https://github.com/shotgunsoftware/python-api.git@v3.4.0
+shotgun-api3==v3.4.0
 wheel
 build
 Sphinx


### PR DESCRIPTION
This make pyshotgrid use shotgun-api3 directly from PyPI.