### PR TITLE
Use shotgun_api3 from tk-core if available

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,14 +8,14 @@ To install pyshotgrid, run this command in your terminal:
 pip install pyshotgrid
 ```
 
-You need to install `shotgun_api3` as a separate step, in case you want to use `pyshotgrid` in
-a standalone application.
 This is the preferred method to install pyshotgrid, as it will always install the most recent stable release.
 
 ## Use pyshotgrid with ShotGrid Toolkit
 
-There are a few ways you can use `pyshotgrid` with ShotGrid Toolkit (SGTK).
-The most straight forward approach would be add to the `sys.path` it in the `tank_init.py`.
+There are a few ways you can use `pyshotgrid` with ShotGrid Toolkit (SGTK) and it will likely
+differ from studio to studio how it should be added to the setup.
+One of the most straight forward approaches would be adding `pyshotgrid` to
+the `sys.path` in the `tank_init.py`.
 
 Here is what you have to do:
 
@@ -26,6 +26,3 @@ Here is what you have to do:
 2. Put it in a central location where everyone can access it
 3. Add the path to the `sys.path` in the `tank_init.py`.
 4. You are done. :) You are now able to use `pyshotgird` throughout your SGTK setup.
-   :::{note}
-   There is no need to install the shotgun_api3 since that is already shipped with SGTK.
-   :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ pretty = true
 [[tool.mypy.overrides]]
 module = [
     "shotgun_api3.*",
+    "tank_vendor.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/shotgunsoftware/tk-core.git@v0.20.4#egg=sgtk
 git+https://github.com/shotgunsoftware/python-api.git@v3.4.0
 commitizen
 wheel

--- a/src/pyshotgrid/core.py
+++ b/src/pyshotgrid/core.py
@@ -5,8 +5,10 @@ import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, Optional, Type, Union  # noqa: F401
 
-import shotgun_api3
-import shotgun_api3.lib.mockgun
+try:
+    import shotgun_api3
+except ImportError:
+    from tank_vendor import shotgun_api3
 
 
 class SGEntity(object):

--- a/src/pyshotgrid/core.py
+++ b/src/pyshotgrid/core.py
@@ -1412,12 +1412,24 @@ def new_site(*args, **kwargs):
     :return: A new instance of the pyshotgrid site.
     """
     if args:
-        if isinstance(args[0], (shotgun_api3.Shotgun, shotgun_api3.lib.mockgun.Shotgun)):
+        # In theory pyshotgrid could live in an environment where
+        # shotgun_api3 and tk-core are installed at the same time.
+        # In this case there are 4 different Shotgun classes that could
+        # work with pyshotgrid:
+        #   - shotgun_api3.Shotgun
+        #   - shotgun_api3.lib.mockgun.Shotgun
+        #   - tank_vendor.shotgun_api3.Shotgun
+        #   - tank_vendor.shotgun_api3.lib.mockgun.Shotgun
+        # pyshotgrid will load either shotgun_api3 or tk-core (tank_vendor.shotgun_api3)
+        # and therefore we cannot use "isinstance" here ,since the user might
+        # pass in a Shotgun class from the other library. We just check
+        # if the passed in object is a instance of a class named "Shotgun".
+        if args[0].__class__.__name__ == "Shotgun":
             sg = args[0]
         else:
-            sg = shotgun_api3.Shotgun(*args)  # pragma: no cover
+            sg = shotgun_api3.Shotgun(*args)
     else:
-        sg = shotgun_api3.Shotgun(**kwargs)  # pragma: no cover
+        sg = shotgun_api3.Shotgun(**kwargs)
     return __SG_SITE_CLASS(sg)
 
 

--- a/src/pyshotgrid/core.py
+++ b/src/pyshotgrid/core.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Type, Union  # noqa: F401
 try:
     import shotgun_api3
 except ImportError:
-    from tank_vendor import shotgun_api3
+    import tank_vendor.shotgun_api3 as shotgun_api3
 
 
 class SGEntity(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,16 +8,27 @@ from shotgun_api3.lib import mockgun
 
 
 @pytest.fixture(params=(True, False))
-def use_tank_vendor(request, monkeypatch):
+def use_shotgun_api3_from_sgtk(request, monkeypatch):
+    """
+    This is a parametrized fixture which will run any test that requests it once against
+    the "regular" pip installed "shotgun_api3" and another time against
+    the vendor-ed "shotgun_api3" in SGTk to ensure the test works in both scenarios.
+    """
     if request.param:
+        # noinspection PyTypeChecker
         monkeypatch.setitem(sys.modules, "shotgun_api3", None)
     else:
+        # noinspection PyTypeChecker
         monkeypatch.setitem(sys.modules, "tank_vendor.shotgun_api3", None)
     return request.param
 
 
 @pytest.fixture()
 def sg():
+    """
+    This fixture sets up a (mockgun.)Shotgun instance with a few useful test entries
+    to test against.
+    """
     resources_dir = os.path.join(os.path.dirname(__file__), "resources")
 
     mockgun_schema_dir = os.path.join(resources_dir, "mockgun_schemas")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,22 @@
 import datetime
 import os
 import random
+import sys
 
 import pytest
 from shotgun_api3.lib import mockgun
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(params=(True, False))
+def use_tank_vendor(request, monkeypatch):
+    if request.param:
+        monkeypatch.setitem(sys.modules, "shotgun_api3", None)
+    else:
+        monkeypatch.setitem(sys.modules, "tank_vendor.shotgun_api3", None)
+    return request.param
+
+
+@pytest.fixture()
 def sg():
     resources_dir = os.path.join(os.path.dirname(__file__), "resources")
 

--- a/tests/test_core/test_core_functions.py
+++ b/tests/test_core/test_core_functions.py
@@ -1,4 +1,6 @@
 """Tests for `pyshotgrid.core` module."""
+import unittest.mock
+
 import pytest
 
 import pyshotgrid as pysg
@@ -100,6 +102,28 @@ def test_new_entity__raises_error_on_wrong_inputs(sg):
 
 def test_new_site(sg):
     sg_site_a = pysg.new_site(sg)
+
+    assert isinstance(sg_site_a, pysg.SGSite)
+
+
+def test_new_site__args(sg):
+    with unittest.mock.patch("shotgun_api3.Shotgun"):
+        sg_site_a = pysg.new_site(
+            "https://test.shotgunstudio.com",
+            "Unittest User",
+            "$ome_password",
+        )
+
+    assert isinstance(sg_site_a, pysg.SGSite)
+
+
+def test_new_site__kwargs(sg):
+    with unittest.mock.patch("shotgun_api3.Shotgun"):
+        sg_site_a = pysg.new_site(
+            base_url="https://test.shotgunstudio.com",
+            script_name="Unittest User",
+            api_key="$ome_password",
+        )
 
     assert isinstance(sg_site_a, pysg.SGSite)
 

--- a/tests/test_core/test_import.py
+++ b/tests/test_core/test_import.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+import importlib
+
+
+def test_import_error(use_tank_vendor):
+    if use_tank_vendor:
+        with pytest.raises(ImportError):
+            import shotgun_api3
+    else:
+        import shotgun_api3
+
+    import pyshotgrid

--- a/tests/test_core/test_import.py
+++ b/tests/test_core/test_import.py
@@ -1,14 +1,9 @@
-import sys
-
-import pytest
 import importlib
 
 
-def test_import_error(use_tank_vendor):
-    if use_tank_vendor:
-        with pytest.raises(ImportError):
-            import shotgun_api3
-    else:
-        import shotgun_api3
-
+def test_import_against_sgtk_vendored_shotgun_api3(use_shotgun_api3_from_sgtk):
     import pyshotgrid
+
+    importlib.reload(pyshotgrid.core)
+    importlib.reload(pyshotgrid.sg_default_entities)
+    importlib.reload(pyshotgrid)


### PR DESCRIPTION
This PR enables pyshotgrid to use the vendored shotgun_api3 in SGTK. 